### PR TITLE
Open Gaming Collective community portal: Display Tesseract badge

### DIFF
--- a/apps/play/pages/games/OpenGamingCollective.tsx
+++ b/apps/play/pages/games/OpenGamingCollective.tsx
@@ -25,19 +25,21 @@ import { hookCommon } from "moonstream-components/src/core/hooks";
 
 const terminusAbi = require("../../../../abi/MockTerminus.json");
 
-type terminusType = "type1" | "type2";
+type terminusType = "type1" | "type2" | "type3";
 
 // TODO: Using an Enum here would make this less clumsy. The Enum defines a type *and* a value.
-const terminusTypes: terminusType[] = ["type1", "type2"];
+const terminusTypes: terminusType[] = ["type1", "type2", "type3"];
 
 const terminusPoolIds: { [key in terminusType]: number } = {
   type1: 1,
   type2: 2,
+  type3: 3,
 };
 
 const defaultBalances: { [key in terminusType]: number } = {
   type1: 0,
   type2: 0,
+  type3: 0,
 };
 
 const OpenGamingCollective = () => {
@@ -128,6 +130,12 @@ const OpenGamingCollective = () => {
         "https://badges.moonstream.to/open-gaming-collective/gr15-i-demoed.png",
       displayName: "Gitcoin GR15: I Demoed!",
       balanceKey: "type2",
+    },
+    {
+      imageUrl:
+        "https://badges.moonstream.to/open-gaming-collective/GR15-OG_Tesseract_final.png",
+      displayName: "Gitcoin GR15: The Open Gaming Tesseract",
+      balanceKey: "type3",
     },
   ];
 
@@ -264,8 +272,8 @@ const OpenGamingCollective = () => {
 
 export async function getStaticProps() {
   const metatags = {
-    title: "Moonstream player portal: Open Gaming Collective",
-    description: "See your badges in the Open Gaming Collective",
+    title: "Moonstream community portal: Open Gaming Collective",
+    description: "See your Open Gaming Collective badges",
   };
   return {
     props: { metaTags: { DEFAULT_METATAGS, ...metatags } },


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Added support for the Gitcoin GR15 Open Gaming Tesseract badge (pool ID: `3`) on the Open Gaming Collective community portal.

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

I tested locally against mainnet.

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
