### PR TITLE
Made normalization of addresses optional on leaderboards

### DIFF
--- a/api/engineapi/actions.py
+++ b/api/engineapi/actions.py
@@ -1080,12 +1080,17 @@ def add_scores(
     leaderboard_id: uuid.UUID,
     scores: List[Score],
     overwrite: bool = False,
+    normalize_addresses: bool = True,
 ):
     """
     Add scores to the leaderboard
     """
 
     leaderboard_scores = []
+
+    normalizer_fn = Web3.toChecksumAddress
+    if not normalize_addresses:
+        normalizer_fn = lambda x: x
 
     if overwrite:
         db_session.query(LeaderboardScores).filter(
@@ -1096,7 +1101,7 @@ def add_scores(
         leaderboard_scores.append(
             {
                 "leaderboard_id": leaderboard_id,
-                "address": Web3.toChecksumAddress(score.address),
+                "address": normalizer_fn(score.address),
                 "score": score.score,
                 "points_data": score.points_data,
             }

--- a/api/engineapi/actions.py
+++ b/api/engineapi/actions.py
@@ -1117,8 +1117,11 @@ def add_scores(
             updated_at=datetime.now(),
         ),
     )
-    db_session.execute(result_stmt)
-    db_session.commit()
+    try:
+        db_session.execute(result_stmt)
+        db_session.commit()
+    except:
+        db_session.rollback()
 
     return leaderboard_scores
 

--- a/api/engineapi/routes/leaderboard.py
+++ b/api/engineapi/routes/leaderboard.py
@@ -97,6 +97,7 @@ async def position(
     window_size: int = 1,
     limit: int = 10,
     offset: int = 0,
+    normalize_addresses: bool = True,
     db_session: Session = Depends(db.yield_db_session),
 ):
 
@@ -105,7 +106,8 @@ async def position(
     With given window size.
     """
 
-    address = Web3.toChecksumAddress(address)
+    if normalize_addresses:
+        address = Web3.toChecksumAddress(address)
 
     positions = actions.get_position(
         db_session, leaderboard_id, address, window_size, limit, offset
@@ -139,8 +141,9 @@ async def leaderboard(
     request: Request,
     leaderboard_id: UUID,
     scores: List[data.Score],
-    db_session: Session = Depends(db.yield_db_session),
     overwrite: bool = False,
+    normalize_addresses: bool = True,
+    db_session: Session = Depends(db.yield_db_session),
 ):
 
     """
@@ -163,6 +166,7 @@ async def leaderboard(
         leaderboard_id=leaderboard_id,
         scores=scores,
         overwrite=overwrite,
+        normalize_addresses=normalize_addresses,
     )
 
     return leaderboard_points


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Made normalization of addresses optional on leaderboards (using `Web3.toChecksumAddress`) when pushing scores, and when reading scores.

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

Tested against local API instance. This is how it was tested:

### Testing

Created two files:

`regular-scores.json`:

```json
[
  {
    "address": "0x0000000000000000000000000000000000000001",
    "score": 200000000,
    "points_data": {
      "something": 100000000,
      "something_else": 100000000
    }
  }
]
```

`token-id-scores.json`:

```json
[
  {
    "address": "1",
    "score": 200000000,
    "points_data": {
      "something": 100000000,
      "something_else": 100000000
    }
  }
]
```


#### Regular scores (address)

To add regular scores:

```bash
curl -X PUT http://localhost:7191/leaderboard/$LEADERBOARD_ID/scores \
    -H "Authorization: Bearer $MOONSTREAM_ADMIN_ACCESS_TOKEN" \
    -H "Content-Type: application/json" \
    -d @regular-scores.json
```

To view:

```bash
curl -s "http://localhost:7191/leaderboard/position?leaderboard_id=$LEADERBOARD_ID&address=0x0000000000000000000000000000000000000001&window_size=0" | jq .
```

Output:

```bash
[
  {
    "address": "0x0000000000000000000000000000000000000001",
    "score": 200000000,
    "rank": 1,
    "number": 1,
    "points_data": {
      "something": 100000000,
      "something_else": 100000000
    }
  }
]
```

#### Token ID scores

To add token id scores:

```bash
curl -X PUT http://localhost:7191/leaderboard/$LEADERBOARD_ID/scores \
    -H "Authorization: Bearer $MOONSTREAM_ADMIN_ACCESS_TOKEN" \
    -H "Content-Type: application/json" \
    -d @token-id-scores.json
```

On `main`, this resulted in an `Internal Server Error`.

Logs from server:

```
... (huge stack trace)
ValueError: Unknown format 1, attempted to normalize to 0x1
```

Even in the head of the PR, the command above results in an `Internal Server Error`. However, if we
add the `normalize_addresses=0` query parameter:

```bash
curl -X PUT "http://localhost:7191/leaderboard/$LEADERBOARD_ID/scores?normalize_addresses=0" \
    -H "Authorization: Bearer $MOONSTREAM_ADMIN_ACCESS_TOKEN" \
    -H "Content-Type: application/json" \
    -d @token-id-scores.json
```

Then no `Internal Server Error`!

To retrieve the position:

```
curl -s "http://localhost:7191/leaderboard/position?leaderboard_id=$LEADERBOARD_ID&address=1"
```

Results in `Internal Server Error`.

But:

```
curl -s "http://localhost:7191/leaderboard/position?leaderboard_id=$LEADERBOARD_ID&address=1&normalize_addresses=false&window_size=0" | jq .
```

Output:

```json
[
  {
    "address": "1",
    "score": 200000000,
    "rank": 1,
    "number": 2,
    "points_data": {
      "something": 100000000,
      "something_else": 100000000
    }
  }
]
```

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

Resolves https://github.com/bugout-dev/engine/issues/215

<!-- Thanks again! :) -->
