### PR TITLE
Add error handling.

### DIFF
--- a/api/engineapi/actions.py
+++ b/api/engineapi/actions.py
@@ -1179,8 +1179,6 @@ def add_scores(
 
         raise DuplicateLeaderboardAddressError("Dublicated addresses", duplicates)
 
-    print(overwrite)
-
     if overwrite:
         db_session.query(LeaderboardScores).filter(
             LeaderboardScores.leaderboard_id == leaderboard_id

--- a/api/engineapi/routes/leaderboard.py
+++ b/api/engineapi/routes/leaderboard.py
@@ -5,7 +5,7 @@ import logging
 from uuid import UUID
 
 from web3 import Web3
-from fastapi import FastAPI, Request, Depends
+from fastapi import FastAPI, Request, Depends, Response
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import NoResultFound
@@ -109,7 +109,7 @@ async def quartiles(
         q1, q2, q3 = actions.get_qurtiles(db_session, leaderboard_id)
 
     except actions.LeaderboardIsEmpty:
-        raise EngineHTTPException(status_code=204, detail="Leaderboard is empty")
+        return Response(status_code=204)
     except Exception as e:
         logger.error(f"Error while getting quartiles: {e}")
         raise EngineHTTPException(status_code=500, detail="Internal server error")

--- a/api/engineapi/routes/leaderboard.py
+++ b/api/engineapi/routes/leaderboard.py
@@ -8,6 +8,7 @@ from web3 import Web3
 from fastapi import FastAPI, Request, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
+from sqlalchemy.orm.exc import NoResultFound
 from typing import List, Optional
 
 from .. import actions
@@ -66,6 +67,18 @@ async def count_addresses(
     Returns the number of addresses in the leaderboard.
     """
 
+    ### Check if leaderboard exists
+    try:
+        actions.get_leaderboard_by_id(db_session, leaderboard_id)
+    except NoResultFound as e:
+        raise EngineHTTPException(
+            status_code=404,
+            detail="Leaderboard not found.",
+        )
+    except Exception as e:
+        logger.error(f"Error while getting leaderboard: {e}")
+        raise EngineHTTPException(status_code=500, detail="Internal server error")
+
     count = actions.get_leaderboard_total_count(db_session, leaderboard_id)
 
     return data.CountAddressesResponse(count=count)
@@ -78,12 +91,28 @@ async def quartiles(
 ):
 
     """
-
     Returns the quartiles of the leaderboard.
-
     """
+    ### Check if leaderboard exists
+    try:
+        actions.get_leaderboard_by_id(db_session, leaderboard_id)
+    except NoResultFound as e:
+        raise EngineHTTPException(
+            status_code=404,
+            detail="Leaderboard not found.",
+        )
+    except Exception as e:
+        logger.error(f"Error while getting leaderboard: {e}")
+        raise EngineHTTPException(status_code=500, detail="Internal server error")
 
-    q1, q2, q3 = actions.get_qurtiles(db_session, leaderboard_id)
+    try:
+        q1, q2, q3 = actions.get_qurtiles(db_session, leaderboard_id)
+
+    except actions.LeaderboardIsEmpty:
+        raise EngineHTTPException(status_code=204, detail="Leaderboard is empty")
+    except Exception as e:
+        logger.error(f"Error while getting quartiles: {e}")
+        raise EngineHTTPException(status_code=500, detail="Internal server error")
 
     return data.QuartilesResponse(
         percentile_25={"address": q1[0], "score": q1[1], "rank": q1[2]},
@@ -108,6 +137,18 @@ async def position(
     With given window size.
     """
 
+    ### Check if leaderboard exists
+    try:
+        actions.get_leaderboard_by_id(db_session, leaderboard_id)
+    except NoResultFound as e:
+        raise EngineHTTPException(
+            status_code=404,
+            detail="Leaderboard not found.",
+        )
+    except Exception as e:
+        logger.error(f"Error while getting leaderboard: {e}")
+        raise EngineHTTPException(status_code=500, detail="Internal server error")
+
     if normalize_addresses:
         address = Web3.toChecksumAddress(address)
 
@@ -130,6 +171,18 @@ async def leaderboard(
     """
     Returns the leaderboard positions.
     """
+
+    ### Check if leaderboard exists
+    try:
+        actions.get_leaderboard_by_id(db_session, leaderboard_id)
+    except NoResultFound as e:
+        raise EngineHTTPException(
+            status_code=404,
+            detail="Leaderboard not found.",
+        )
+    except Exception as e:
+        logger.error(f"Error while getting leaderboard: {e}")
+        raise EngineHTTPException(status_code=500, detail="Internal server error")
 
     leaderboard_positions = actions.get_leaderboard_positions(
         db_session, leaderboard_id, limit, offset
@@ -159,6 +212,19 @@ async def rank(
     """
     Returns the leaderboard scores for the given rank.
     """
+
+    ### Check if leaderboard exists
+    try:
+        actions.get_leaderboard_by_id(db_session, leaderboard_id)
+    except NoResultFound as e:
+        raise EngineHTTPException(
+            status_code=404,
+            detail="Leaderboard not found.",
+        )
+    except Exception as e:
+        logger.error(f"Error while getting leaderboard: {e}")
+        raise EngineHTTPException(status_code=500, detail="Internal server error")
+
     leaderboard_rank = actions.get_rank(
         db_session, leaderboard_id, rank, limit=limit, offset=offset
     )
@@ -182,6 +248,19 @@ async def ranks(
     """
     Returns the leaderboard rank buckets overview with score and size of bucket.
     """
+
+    ### Check if leaderboard exists
+    try:
+        actions.get_leaderboard_by_id(db_session, leaderboard_id)
+    except NoResultFound as e:
+        raise EngineHTTPException(
+            status_code=404,
+            detail="Leaderboard not found.",
+        )
+    except Exception as e:
+        logger.error(f"Error while getting leaderboard: {e}")
+        raise EngineHTTPException(status_code=500, detail="Internal server error")
+
     ranks = actions.get_ranks(db_session, leaderboard_id)
     results = [
         data.RanksResponse(
@@ -218,6 +297,19 @@ async def leaderboard(
         raise EngineHTTPException(
             status_code=403, detail="You don't have access to this leaderboard."
         )
+
+    ### Check if leaderboard exists
+    try:
+        actions.get_leaderboard_by_id(db_session, leaderboard_id)
+    except NoResultFound as e:
+        raise EngineHTTPException(
+            status_code=404,
+            detail="Leaderboard not found.",
+        )
+    except Exception as e:
+        logger.error(f"Error while getting leaderboard: {e}")
+        raise EngineHTTPException(status_code=500, detail="Internal server error")
+
     try:
         leaderboard_points = actions.add_scores(
             db_session=db_session,
@@ -230,6 +322,12 @@ async def leaderboard(
         raise EngineHTTPException(
             status_code=409,
             detail=f"Duplicates in push to database is disallowed.\n List of duplicates:{e.duplicates}.\n Please handle duplicates manualy.",
+        )
+    except actions.LeaderboardDeleteScoresError as e:
+        logger.error(f"Delete scores failed with error: {e}")
+        raise EngineHTTPException(
+            status_code=500,
+            detail=f"Delete scores failed.",
         )
     except Exception as e:
         logger.error(f"Score update failed with error: {e}")


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Add check if leaderboard exists.
Add check if leadeboard not empty for quartiles endpoint.
Add check if overwrite was successfull.

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

Manual.


```

### Get leaderboard
GET http://localhost:7191/leaderboard/?leaderboard_id=<leaderboard_id>

### Get quartiles of leaderboard
GET http://localhost:7191/leaderboard/quartiles/?leaderboard_id=<leaderboard_id>

### Get count of addresses/nfts in leaderboard
GET http://localhost:7191/leaderboard/count/addresses/?leaderboard_id=<leaderboard_id>

### Get particular position of addresses/nfts in leaderboard
GET http://localhost:7191/leaderboard/position/?leaderboard_id=<leaderboard_id>&address=0x2b563420722cBcFC84857129Bef775e0dC5F1401

### Get addresses/nfts with rank in leaderboard
GET http://localhost:7191/leaderboard/rank/?leaderboard_id=<leaderboard_id>&rank=1

###  Get existing ranks
GET https://engineapi.moonstream.to/leaderboard/ranks?leaderboard_id=<leaderboard_id>


Push data.

### With normalizattion
PUT http://localhost:7191/leaderboard/42c0dd2d-a43b-4898-b84e-74d51e0dc0eb/scores?overwrite=true&normalize_addresses=false
Authorization: Bearer <token>
Content-Type: application/json
[
    {
        "address": "0xe52f498307bd4252bd5e6a49d6be93cfebc4cd41",
        "score": 45,
        "points_data": {
            "breed": 20,
            "evo": 25,
            "evolve_1300": 0,
            "mythic_parts": 0,
            "num_cornucopia ": 0
        }
    }
]


### Without normalization.
PUT http://localhost:7191/leaderboard/42c0dd2d-a43b-4898-b84e-74d51e0dc0eb/scores?overwrite=true&normalize_addresses=false
Authorization: Bearer <token>
Content-Type: application/json
[  
  {
    "address": "113",
    "score": 400,
    "points_data": {
      "session_2": 400
    }
  }
]
```

Docs:
https://www.notion.so/Leaderboards-API-doc-e9fe35c6ae9944a6b1d40d49ed1acdda

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
