### PR TITLE
Inheritable DropperV2

### DIFF
--- a/contracts/Dropper/DropperFacet.sol
+++ b/contracts/Dropper/DropperFacet.sol
@@ -171,7 +171,7 @@ contract DropperFacet is
     }
 
     function getDrop(uint256 dropId)
-        external
+        public
         view
         returns (DroppableToken memory)
     {
@@ -222,7 +222,7 @@ contract DropperFacet is
         address claimant,
         uint256 blockDeadline,
         uint256 amount
-    ) public view returns (bytes32) {
+    ) public virtual view returns (bytes32) {
         bytes32 structHash = keccak256(
             abi.encode(
                 keccak256(
@@ -245,7 +245,7 @@ contract DropperFacet is
         uint256 blockDeadline,
         uint256 amount,
         bytes memory signature
-    ) external diamondNonReentrant {
+    ) public virtual diamondNonReentrant {
         require(
             block.number <= blockDeadline,
             "Dropper: claim -- Block deadline exceeded."

--- a/contracts/Dropper/DropperFacet.sol
+++ b/contracts/Dropper/DropperFacet.sol
@@ -222,7 +222,7 @@ contract DropperFacet is
         address claimant,
         uint256 blockDeadline,
         uint256 amount
-    ) public virtual view returns (bytes32) {
+    ) public view virtual returns (bytes32) {
         bytes32 structHash = keccak256(
             abi.encode(
                 keccak256(
@@ -252,6 +252,11 @@ contract DropperFacet is
         );
 
         LibDropper.DropperStorage storage ds = LibDropper.dropperStorage();
+
+        require(
+            ds.IsDropActive[dropId],
+            "Dropper: claim -- cannot claim inactive drop"
+        );
 
         require(
             !ds.DropRequestClaimed[dropId][requestID],


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->
The following changes are implemented in DropperV2 to enable the satellite bank to inherit from it.

## Changes

- mark `claim` and `claimMessageHash` as `virtual` functions
- mark `claim` as `public` function
- mark `getDrop` as `public` function
- Added require in `claim` function to check `isDropActive`

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?
`cd cli` - Move to `cli` directory
`./test.sh enginecli.test_dropper` - Run this command to test dropper
<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
